### PR TITLE
Fix animation breakage when using solver and manual input

### DIFF
--- a/cubito/GameController.hpp
+++ b/cubito/GameController.hpp
@@ -17,6 +17,7 @@
 #include "Rendered.hpp"
 #include "Resources.hpp"
 #include "Setting.hpp"
+#include "solver/Rubik.hpp"
 
 class GameController {
 
@@ -86,15 +87,14 @@ class GameController {
   void Render();
   void ResetAngles();
   void PlayAnimation();
-  void UpdateGame(float);
-  void ProcessInput(float);
+  void UpdateGame();
+  void ProcessInput();
   void UpdateMatrices(glm::mat4, glm::mat4, glm::mat4);
   glm::vec3 CalculateTranslatePosition(float, Move, const float&);
 
   void StartParser();
   std::string GenScramble(int);
   std::vector<Move> ParseOutput(std::string);
-
 };
 
 // --------------------------------------------------------------------------------------
@@ -411,131 +411,135 @@ void GameController::Init() {
   }
 }
 
-void GameController::ProcessInput(float delta_time) {
-    if (( this->keys_press[GLFW_KEY_RIGHT_SHIFT] && !this->keys_already_press[GLFW_KEY_RIGHT_SHIFT]) ||
-      (this->keys_press[GLFW_KEY_LEFT_SHIFT] && !this->keys_already_press[GLFW_KEY_LEFT_SHIFT])) {
-      
-        if (this->keys_press[GLFW_KEY_U] && !this->keys_already_press[GLFW_KEY_U])
-        {
-          U_PRIME_ANIM = true;
-          U_PRIME_ANIM_I = true;
-          this->can_press = false;
-          this->some_movement = true;
-          this->keys_already_press[GLFW_KEY_U] = true;
-          this->keys_already_press[GLFW_KEY_RIGHT_SHIFT] = true;
-          this->keys_already_press[GLFW_KEY_LEFT_SHIFT] = true;
-        }
-
-        if (this->keys_press[GLFW_KEY_D] && !this->keys_already_press[GLFW_KEY_D])
-        {
-          D_PRIME_ANIM = true;
-          D_PRIME_ANIM_I = true;
-          this->can_press = false;
-          this->some_movement = true;
-          this->keys_already_press[GLFW_KEY_D] = true;
-          this->keys_already_press[GLFW_KEY_RIGHT_SHIFT] = true;
-          this->keys_already_press[GLFW_KEY_LEFT_SHIFT] = true;
-        }
-
-        if (this->keys_press[GLFW_KEY_R] && !this->keys_already_press[GLFW_KEY_R])
-        {
-          R_ANIM = true;
-          R_ANIM_I = true;
-          this->can_press = false;
-          this->some_movement = true;
-          this->keys_already_press[GLFW_KEY_R] = true;
-          this->keys_already_press[GLFW_KEY_RIGHT_SHIFT] = true;
-          this->keys_already_press[GLFW_KEY_LEFT_SHIFT] = true;
-        }
-        
-        if (this->keys_press[GLFW_KEY_L] && !this->keys_already_press[GLFW_KEY_L])
-        {
-          L_PRIME_ANIM = true;
-          L_PRIME_ANIM_I = true;
-          this->can_press = false;
-          this->some_movement = true;
-          this->keys_already_press[GLFW_KEY_L] = true;
-          this->keys_already_press[GLFW_KEY_RIGHT_SHIFT] = true;
-          this->keys_already_press[GLFW_KEY_LEFT_SHIFT] = true;
-        }
-
-        if (this->keys_press[GLFW_KEY_F] && !this->keys_already_press[GLFW_KEY_F])
-        {
-          F_PRIME_ANIM = true;
-          F_PRIME_ANIM_I = true;
-          this->can_press = false;
-          this->some_movement = true;
-          this->keys_already_press[GLFW_KEY_F] = true;
-          this->keys_already_press[GLFW_KEY_RIGHT_SHIFT] = true;
-          this->keys_already_press[GLFW_KEY_LEFT_SHIFT] = true;
-        }
-      
-        if (this->keys_press[GLFW_KEY_B] && !this->keys_already_press[GLFW_KEY_B])
-        {
-          B_ANIM = true;
-          B_ANIM_I = true;
-          this->can_press = false;
-          this->some_movement = true;
-          this->keys_already_press[GLFW_KEY_B] = true;
-          this->keys_already_press[GLFW_KEY_RIGHT_SHIFT] = true;
-          this->keys_already_press[GLFW_KEY_LEFT_SHIFT] = true;
-        }
+void GameController::ProcessInput() {
+  if (this->keys_press[GLFW_KEY_RIGHT_SHIFT] ||
+      this->keys_press[GLFW_KEY_LEFT_SHIFT]) {
+    if (this->keys_press[GLFW_KEY_U] && !this->keys_already_press[GLFW_KEY_U]) {
+      this->U_PRIME_ANIM = true;
+      this->U_PRIME_ANIM_I = true;
+      this->can_press = false;
+      this->some_movement = true;
+      this->keys_already_press[GLFW_KEY_U] = true;
+      this->str_scramble += "U' ";
     }
-    else {
-      if (this->keys_press[GLFW_KEY_U] && !this->keys_already_press[GLFW_KEY_U])
-      {
-        U_ANIM = true;
-        U_ANIM_I = true;
-        this->can_press = false;
-        this->some_movement = true;
-        this->keys_already_press[GLFW_KEY_U] = true;
-      }
 
-      if (this->keys_press[GLFW_KEY_D] && !this->keys_already_press[GLFW_KEY_D])
-      {
-        D_ANIM = true;
-        D_ANIM_I = true;
-        this->some_movement = true;
-        this->can_press = false;
-        this->keys_already_press[GLFW_KEY_D] = true;
-      }
-
-      if (this->keys_press[GLFW_KEY_R] && !this->keys_already_press[GLFW_KEY_R])
-      {
-        R_PRIME_ANIM = true;
-        R_PRIME_ANIM_I = true;
-        this->can_press = false;
-        this->some_movement = true;
-        this->keys_already_press[GLFW_KEY_R] = true;
-      }
-      
-      if (this->keys_press[GLFW_KEY_L] && !this->keys_already_press[GLFW_KEY_L])
-      {
-        L_ANIM = true;
-        L_ANIM_I = true;
-        this->can_press = false;
-        this->some_movement = true;
-        this->keys_already_press[GLFW_KEY_L] = true;
-      }
-      
-      if (this->keys_press[GLFW_KEY_F] && !this->keys_already_press[GLFW_KEY_F])
-      {
-        F_ANIM = true;
-        F_ANIM_I = true;
-        this->can_press = false;
-        this->some_movement = true;
-        this->keys_already_press[GLFW_KEY_F] = true;
-      }
-     
-      if (this->keys_press[GLFW_KEY_B] && !this->keys_already_press[GLFW_KEY_B])
-      {
-        B_PRIME_ANIM = true;
-        B_PRIME_ANIM_I = true;
-        this->can_press = false;
-        this->some_movement = true;
-        this->keys_already_press[GLFW_KEY_B] = true;
-      }
+    if (this->keys_press[GLFW_KEY_D] && !this->keys_already_press[GLFW_KEY_D]) {
+      this->D_PRIME_ANIM = true;
+      this->D_PRIME_ANIM_I = true;
+      this->can_press = false;
+      this->some_movement = true;
+      this->keys_already_press[GLFW_KEY_D] = true;
+      this->str_scramble += "D' ";
     }
+
+    if (this->keys_press[GLFW_KEY_R] && !this->keys_already_press[GLFW_KEY_R]) {
+      this->R_ANIM = true;
+      this->R_ANIM_I = true;
+      this->can_press = false;
+      this->some_movement = true;
+      this->keys_already_press[GLFW_KEY_R] = true;
+      this->str_scramble += "R' ";
+    }
+
+    if (this->keys_press[GLFW_KEY_L] && !this->keys_already_press[GLFW_KEY_L]) {
+      this->L_PRIME_ANIM = true;
+      this->L_PRIME_ANIM_I = true;
+      this->can_press = false;
+      this->some_movement = true;
+      this->keys_already_press[GLFW_KEY_L] = true;
+      this->str_scramble += "L' ";
+    }
+
+    if (this->keys_press[GLFW_KEY_F] && !this->keys_already_press[GLFW_KEY_F]) {
+      this->F_PRIME_ANIM = true;
+      this->F_PRIME_ANIM_I = true;
+      this->can_press = false;
+      this->some_movement = true;
+      this->keys_already_press[GLFW_KEY_F] = true;
+      this->str_scramble += "F' ";
+    }
+
+    if (this->keys_press[GLFW_KEY_B] && !this->keys_already_press[GLFW_KEY_B]) {
+      this->B_ANIM = true;
+      this->B_ANIM_I = true;
+      this->can_press = false;
+      this->some_movement = true;
+      this->keys_already_press[GLFW_KEY_B] = true;
+      this->str_scramble += "B' ";
+    }
+  }
+  else {
+    if (this->keys_press[GLFW_KEY_U] && !this->keys_already_press[GLFW_KEY_U]) {
+      this->U_ANIM = true;
+      this->U_ANIM_I = true;
+      this->can_press = false;
+      this->some_movement = true;
+      this->keys_already_press[GLFW_KEY_U] = true;
+      this->str_scramble += "U ";
+    }
+
+    if (this->keys_press[GLFW_KEY_D] && !this->keys_already_press[GLFW_KEY_D]) {
+      this->D_ANIM = true;
+      this->D_ANIM_I = true;
+      this->some_movement = true;
+      this->can_press = false;
+      this->keys_already_press[GLFW_KEY_D] = true;
+      this->str_scramble += "D ";
+    }
+
+    if (this->keys_press[GLFW_KEY_R] && !this->keys_already_press[GLFW_KEY_R]) {
+      this->R_PRIME_ANIM = true;
+      this->R_PRIME_ANIM_I = true;
+      this->can_press = false;
+      this->some_movement = true;
+      this->keys_already_press[GLFW_KEY_R] = true;
+      this->str_scramble += "R ";
+    }
+
+    if (this->keys_press[GLFW_KEY_L] && !this->keys_already_press[GLFW_KEY_L]) {
+      this->L_ANIM = true;
+      this->L_ANIM_I = true;
+      this->can_press = false;
+      this->some_movement = true;
+      this->keys_already_press[GLFW_KEY_L] = true;
+      this->str_scramble += "L ";
+    }
+
+    if (this->keys_press[GLFW_KEY_F] && !this->keys_already_press[GLFW_KEY_F]) {
+      this->F_ANIM = true;
+      this->F_ANIM_I = true;
+      this->can_press = false;
+      this->some_movement = true;
+      this->keys_already_press[GLFW_KEY_F] = true;
+      this->str_scramble += "F ";
+    }
+
+    if (this->keys_press[GLFW_KEY_B] && !this->keys_already_press[GLFW_KEY_B]) {
+      this->B_PRIME_ANIM = true;
+      this->B_PRIME_ANIM_I = true;
+      this->can_press = false;
+      this->some_movement = true;
+      this->keys_already_press[GLFW_KEY_B] = true;
+      this->str_scramble += "B ";
+    }
+  }
+
+  if (this->keys_press[GLFW_KEY_Z] && !this->keys_already_press[GLFW_KEY_Z]) {
+    std::string new_str_scramble = GenScramble(10);
+    this->scramble = ParseOutput(new_str_scramble);
+    this->str_scramble += new_str_scramble;
+    this->can_press = false;
+    this->shuffle_anim = true;
+    this->keys_already_press[GLFW_KEY_Z] = true;
+  }
+
+  if (this->keys_press[GLFW_KEY_X] && !this->keys_already_press[GLFW_KEY_X]) {
+    this->str_solution = rubik::solve(str_scramble);
+    this->solution = ParseOutput(str_solution);
+    this->can_press = false;
+    this->solution_anim = true;
+    this->keys_already_press[GLFW_KEY_X] = true;
+  }
 }
 
 void GameController::Render() {
@@ -557,12 +561,12 @@ void GameController::ResetAngles() {
   move_angles[8] = 315.0f;
 }
 
-void GameController::UpdateGame(float delta_time) {
+void GameController::UpdateGame() {
   if (this->some_movement) {
     this->PlayAnimation();
   }
   else {
-    if (shuffle_anim) {
+    if (this->shuffle_anim) {
       if (idx_scramble == scramble.size()) {
         shuffle_anim = false;
         scramble.clear();
@@ -842,6 +846,7 @@ void GameController::PlayAnimation() {
     U_PRIME_ANIM = false;
     D_ANIM = false;
     D_PRIME_ANIM = false;
+    can_press = true;
   }
 }
 

--- a/cubito/main.cpp
+++ b/cubito/main.cpp
@@ -32,9 +32,7 @@
 #include "stb_image.h"
 #include "Shader.h"
 #include "GameController.hpp"
-#include "solver/Rubik.hpp"
 #include "Setting.hpp"
-
 
 // IF YOU WANT TO KNOW INFO AFTER ONE MOVEMENT
 #define DEBUG 0
@@ -111,11 +109,11 @@ int main(int argc, char *argv[]) {
     view = camera.GetViewMatrix();
 
     // God actions
-    game_controller.ProcessInput(deltaTime);
+    game_controller.ProcessInput();
     
     game_controller.UpdateMatrices(model,view,projection);
 
-    game_controller.UpdateGame(deltaTime);
+    game_controller.UpdateGame();
 
     // Render All
     glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
@@ -136,124 +134,21 @@ void key_callback(GLFWwindow* window, int key, int scancode, int action,
   if (key == GLFW_KEY_ESCAPE && action == GLFW_PRESS)
     glfwSetWindowShouldClose(window, true);
 
-  if (game_controller.can_press) {
+  if (key == GLFW_KEY_LEFT_SHIFT ||
+      key == GLFW_KEY_RIGHT_SHIFT) {
+    game_controller.keys_press[key] = true;
+  }
+
+  if (game_controller.can_press && !game_controller.shuffle_anim
+      && !game_controller.solution_anim) {
     if (key >= 0 && key < 1024)
       if (action == GLFW_PRESS)
         game_controller.keys_press[key] = true;
   }
-  else {}
 
   if (action == GLFW_RELEASE) {
     game_controller.keys_press[key] = false;
     game_controller.keys_already_press[key] = false;
-  }
-
-  // Solver
-  if (!game_controller.solution_anim && !game_controller.shuffle_anim
-      && !game_controller.some_movement) {
-    if (glfwGetKey(window, GLFW_KEY_Z) == GLFW_PRESS) {
-      std::string new_str_scramble = game_controller.GenScramble(10);
-      game_controller.scramble = game_controller.ParseOutput(new_str_scramble);
-      game_controller.str_scramble += new_str_scramble;
-      game_controller.shuffle_anim = true;
-    }
-
-    if (glfwGetKey(window, GLFW_KEY_X) == GLFW_PRESS) {
-      if (!game_controller.str_scramble.empty()) {
-       game_controller.str_solution = rubik::solve(game_controller.str_scramble);
-       game_controller.solution = game_controller.ParseOutput(game_controller.str_solution);
-       game_controller.solution_anim = true;
-      }
-    }
-
-    // Standard rubik's cube movements
-    if (glfwGetKey(window, GLFW_KEY_RIGHT_SHIFT) == GLFW_PRESS ||
-        glfwGetKey(window, GLFW_KEY_LEFT_SHIFT) == GLFW_PRESS) {
-      if (glfwGetKey(window, GLFW_KEY_U) == GLFW_PRESS) {
-        game_controller.U_PRIME_ANIM = true;
-        game_controller.U_PRIME_ANIM_I = true;
-        game_controller.some_movement = true;
-        game_controller.str_scramble += "U' ";
-      }
-
-      if (glfwGetKey(window, GLFW_KEY_D) == GLFW_PRESS) {
-        game_controller.D_PRIME_ANIM = true;
-        game_controller.D_PRIME_ANIM_I = true;
-        game_controller.some_movement = true;
-        game_controller.str_scramble += "D' ";
-      }
-
-      if (glfwGetKey(window, GLFW_KEY_R) == GLFW_PRESS) {
-        game_controller.R_ANIM = true;
-        game_controller.R_ANIM_I = true;
-        game_controller.some_movement = true;
-        game_controller.str_scramble += "R' ";
-      }
-
-      if (glfwGetKey(window, GLFW_KEY_L) == GLFW_PRESS) {
-        game_controller.L_PRIME_ANIM = true;
-        game_controller.L_PRIME_ANIM_I = true;
-        game_controller.some_movement = true;
-        game_controller.str_scramble += "L' ";
-      }
-
-      if (glfwGetKey(window, GLFW_KEY_F) == GLFW_PRESS) {
-        game_controller.F_PRIME_ANIM = true;
-        game_controller.F_PRIME_ANIM_I = true;
-        game_controller.some_movement = true;
-        game_controller.str_scramble += "F' ";
-      }
-
-      if (glfwGetKey(window, GLFW_KEY_B) == GLFW_PRESS) {
-        game_controller.B_ANIM = true;
-        game_controller.B_ANIM_I = true;
-        game_controller.some_movement = true;
-        game_controller.str_scramble += "B' ";
-      }
-    }
-    else {
-      if (glfwGetKey(window, GLFW_KEY_U) == GLFW_PRESS) {
-        game_controller.U_ANIM = true;
-        game_controller.U_ANIM_I = true;
-        game_controller.some_movement = true;
-        game_controller.str_scramble += "U ";
-      }
-
-      if (glfwGetKey(window, GLFW_KEY_D) == GLFW_PRESS) {
-        game_controller.D_ANIM = true;
-        game_controller.D_ANIM_I = true;
-        game_controller.some_movement = true;
-        game_controller.str_scramble += "D ";
-      }
-
-      if (glfwGetKey(window, GLFW_KEY_R) == GLFW_PRESS) {
-        game_controller.R_PRIME_ANIM = true;
-        game_controller.R_PRIME_ANIM_I = true;
-        game_controller.some_movement = true;
-        game_controller.str_scramble += "R ";
-      }
-
-      if (glfwGetKey(window, GLFW_KEY_L) == GLFW_PRESS) {
-        game_controller.L_ANIM = true;
-        game_controller.L_ANIM_I = true;
-        game_controller.some_movement = true;
-        game_controller.str_scramble += "L ";
-      }
-
-      if (glfwGetKey(window, GLFW_KEY_F) == GLFW_PRESS) {
-        game_controller.F_ANIM = true;
-        game_controller.F_ANIM_I = true;
-        game_controller.some_movement = true;
-        game_controller.str_scramble += "F ";
-      }
-
-      if (glfwGetKey(window, GLFW_KEY_B) == GLFW_PRESS) {
-        game_controller.B_PRIME_ANIM = true;
-        game_controller.B_PRIME_ANIM_I = true;
-        game_controller.some_movement = true;
-        game_controller.str_scramble += "B ";
-      }
-    }
   }
 }
 


### PR DESCRIPTION
Moved solver's key_callback into GameController's ProcessInput.
There are still some occasions where the solver can't solve it (because some movements seem to be committed or misplaced when scrambling automatically and pressing manual input).